### PR TITLE
Removed gulp-util dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var gutil = require('gulp-util');
+var replaceExtension = require('replace-ext');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var whitespace = require('css-whitespace');
 
@@ -12,12 +13,12 @@ module.exports = function(opts) {
     }
 
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-css-whitespace', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-css-whitespace', 'Streaming not supported'));
       return cb();
     }
 
     if(opts.replaceExtension) {
-      file.path = gutil.replaceExtension(file.path, opts.replaceExtension);
+      file.path = replaceExtension(file.path, opts.replaceExtension);
     }
 
     try {
@@ -26,7 +27,7 @@ module.exports = function(opts) {
       file.contents = new Buffer(str);
     } catch (err) {
       err.fileName = file.path;
-      this.emit('error', new gutil.PluginError('gulp-css-whitespace', err));
+      this.emit('error', new PluginError('gulp-css-whitespace', err));
     }
 
     this.push(file);

--- a/package.json
+++ b/package.json
@@ -4,14 +4,11 @@
   "description": "Converts white-space significant CSS to normal CSS",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
     "url": "git://git@github.com/rschmukler/gulp-css-whitespace"
-  },
-  "scripts": {
-    "test": "mocha"
   },
   "files": [
     "index.js"
@@ -28,8 +25,9 @@
   },
   "dependencies": {
     "css-whitespace": "~1.1.0",
-    "through2": "^0.5.1",
-    "gulp-util": "~3.0"
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
+    "through2": "^0.5.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
The 'gulp-util' package is being oficially deprecated (as in, will not work with Gulp 4). I'm just going through and removing it from packages where I can, and replacing it with suitable alternatives.